### PR TITLE
fix(reports): prevent Charts crash on rapid month navigation

### DIFF
--- a/PresentApp/Views/Reports/ReportDatePickerPopover.swift
+++ b/PresentApp/Views/Reports/ReportDatePickerPopover.swift
@@ -143,6 +143,11 @@ struct ReportDatePickerPopover: View {
 /// (which write to `pickerYear`) and grid cell modifiers (which read it)
 /// are fully isolated from the parent's dependency graph, preventing
 /// AttributeGraph cycles.
+///
+/// **Why `.id(pickerYear)`?** Without it, SwiftUI logs AttributeGraph cycle
+/// warnings when `pickerYear` changes — even with `MonthCell` extracted as a
+/// standalone struct (#253). Removal was evaluated in #275; the warnings
+/// persisted, so the modifier stays until the root cause is resolved.
 private struct ReportMonthPicker: View {
     @Environment(ThemeManager.self) private var theme
 

--- a/PresentApp/Views/Reports/ReportsView.swift
+++ b/PresentApp/Views/Reports/ReportsView.swift
@@ -552,7 +552,12 @@ struct ReportsView: View {
             }
         }
 
-        return entries
+        // During async reload transitions, selectedDate (which drives xAxisDomain) may
+        // advance while summary data is stale from the previous period. Filter out entries
+        // whose labels fall outside the current domain to prevent Swift Charts from asserting
+        // on out-of-domain x-values in .chartXScale(domain:). See #275.
+        let validLabels = Set(xAxisDomain)
+        return entries.filter { validLabels.contains($0.label) }
     }
 
     private var weeklyTooltipLabelMap: [String: String] {


### PR DESCRIPTION
## Summary

- Filters `barEntries` to exclude day labels outside the current month's x-axis domain, preventing a Swift Charts assertion crash when stale summary data is still in flight during rapid navigation
- Documents why `.id(pickerYear)` must remain on `ReportMonthPicker` — removal was evaluated as part of #275 and AttributeGraph warnings persisted

## Referenced Issues

### Closes
- Closes #275

## Test Plan

- Open Reports in monthly mode, open the date picker popover, navigate rapidly with the main chevrons across year boundaries (Dec → Jan → Feb) — no crash
- Verify bar chart renders correctly after settling on any month