### PR TITLE
fix(release): scope changelog to current milestone, not full history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
 ## [0.2.1] - 2026-03-22
 
 ### Added
@@ -68,87 +69,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add Launch on Login preference
 - add Light/Dark/System appearance mode preference
 - add daily timeline chart to single-day report
-- add findOrCreateTag to prevent duplicate tag errors
-- add duplicate check and cross-linking to issue skill
-- surface full version string including pre-release identifiers
-- expand settings gear into labeled pill on hover
-- add hover highlight to Launch Present footer row
-- add "Launch Present" footer link and macwindow icon
-- extend session context menu to active sessions
-- add delete session via right-click context menu
-- version DMG filenames and remove broken stable release workflow
-- add standalone break expiry alert with session context (#49)
-- overhaul floating alert UI for rhythm focus expiry (#49)
-- polish break expiry alert UI
-- add EditPillButton shared component
-- round UI durations to nearest minute before summing
-- show live duration for active session in breakdown card
-- add day labels for cross-midnight session times
-- add informational panel for Break system activity
-- surface Break as read-only system activity in UI
-- add timer-end floating alert with break and restart actions (#49)
-- improve activity breakdown card legibility
-- add lotus bloom animation to header
-- add rich hover tooltip to day timeline
-- add semantic typography tokens and migrate views
-- add zoom support with scaled fonts
-- add Cmd+/- text zoom for main window
-- edit icon opens activity in main app
-- add session delete command
-- add day timeline graph to today's summary
-- show active sessions in breakdown with live timer and spinning icon; fix state icons per session type
-- replace session/summary cards with unified header
-- auto-label new issues with Claude Code
-- add local-assets directory to .gitignore
-- simplify data management section
-- expandable activity breakdown with striped rows
-- add onHoverStart callback for hover events
-- add weekend background bands to bar charts
-- add weekly stacked bar chart
-- surface CLI version and outdated install warning
-- show CLI version status in CLI settings tab
-- add session add command and rename search to list
-- add backdated session, setActivityTags, and activitySummary
-- add Cmd+N keyboard shortcut for New Activity
-- consolidate session log into reports page
-- add empty state placeholder for periods with no sessions
-- replace bottom bar buttons with settings gear icon
-- add external ID breakdown donut chart
-- replace click-to-edit links with always-editable fields
-- add smart list continuation in markdown editor
-- add inline editing for activity links with hover-to-edit UX
-- add explicit cancel actions for inline editing
-- move action buttons to footer with timestamps
-- replace modal edit with inline editing and redesigned layout
-- display user-facing error feedback for failed operations
-- add stacked bar chart breakdown for tag distribution
-- add interactive legend to donut chart
-- smooth fade-out animation for cancel button
-- add week start preference picker
-- redesign charts with consistent axes and improved layout
-- make CSV export CLI-only with archive flag
-- add timer linger with flash/fade and enhance recent session display
-- add dusty palette and visual picker in settings
-- add dynamic color palette system with basic and modern themes
-- add layered Icon Composer format with dynamic gradient
-- update app icon to v3 lotus clock design and set version to 0.1
-- restructure to noun-verb pattern with input validation
-- route all issue filing and PM tasks through PM agent
-- add pm agent for issue triage and backlog management
-- add auto-generated CLI reference documentation
-- add configurable default timebound duration
-- add app icon asset catalog and display in About page
-- pair break duration with focus time in rhythm options
-- add SF Symbol icons to right-click context menu items
-- show activity names in context menu actions
-- add danger zone with bulk deletion operations
-- add recent session restart suggestion
-- add clear button and dynamic label to activity search
-- add sound effects system for session lifecycle events
-- make rhythm cycle length configurable
-- add quick-create field, row redesign, and inline editing
-- add About tab and Settings button to main window
-- add session type picker to menubar and activity detail
 
 ### Changed
 - extract shared _classify_commit() to deduplicate parsing
@@ -223,24 +143,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - extract data refresh into DataRefreshCoordinator
 - extract timer state into TimerManager
 - extract zoom state into ZoomManager
-- restore trailing commas in CommandConfiguration calls
-- use filled SF Symbol variants in session menus
-- update card titles to match app voice
-- centralize rhythm duration formatting via RhythmOption
-- restructure header with proportional layout
-- unify quick-restart rows with shared QuickStartRow
-- bump CLI help text font from footnote to callout
-- extract week range formatting; add subtitle to ChartCard
-- extract shared Font tokens for dashboard greeting and period header
-- migrate hardcoded padding to Constants.spacing* values
-- extract shared chart components from ReportsView
-- extract shared StatItem and flatten today summary
-- restructure session and report commands (Phase 4, #33)
-- restructure activity tag commands into SALR subgroup
-- simplify archive filtering to always include archived activities
-- use primary color for navigation chrome selection states
-- remove non-functional timebox scaffolding
-- delete cancelled sessions instead of marking status
 
 ### Fixed
 - handle empty grep in release.sh previous tag lookup
@@ -402,111 +304,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - replace force unwraps with safe guard let in ActivityDetailView
 - replace force unwraps in GRDB row decoding
 - refresh app state on incoming IPC messages
-- scope error alerts to their originating scene
-- resolve compiler warnings in app and tests
-- bump Xcode to 16.3 for Swift 6.1 trailing comma support
-- bump Xcode to 16.2 to fix Swift Testing segfault
-- grant write permission so cli-docs bot can push
-- remove trailing commas from CommandConfiguration argument lists
-- add contents:read permission to milestone version issue workflow
-- read MARKETING_VERSION from project.yml in beta-release.sh
-- render timeline segments instead of session blocks
-- show floating alert when app is inactive
-- bring window to front before opening from menu bar
-- pulse weekly chart active segment
-- port hover fixes from reports chart to Your Week
-- verify local main matches origin/main before beta build
-- increase bottom bar vertical padding to clear popover corner
-- resize "Launch Present" footer to body font
-- use adaptive foreground color in floating alert buttons
-- fix cross-midnight attribution in activity, tag, and tag-activity summaries
-- apply minute rounding to tag activity summary
-- fix stacked bar chart overlay blocking legend hover
-- show weekly chart during first session of the week
-- remove unused recentId binding in FloatingAlertView
-- prepend Gatekeeper workaround to beta release notes (#63)
-- checkout repo before invoking local composite action
-- align alert button copy with voice & tone conventions (#49)
-- apply consistent alert patterns to timebound window (#49)
-- refine ResumeActivityCard and SteamingCupIcon styles
-- restyle break alert resume card and end button
-- prevent Swift Charts crash on session start from menu bar
-- stabilize EditPillButton hover animation
-- use Xh Ym format for all chart tooltips
-- refine session row icons and duration format
-- show segment-based today/total split for cross-midnight sessions
-- disallow rhythm sessions on system activities
-- clarify break-completion alert actions
-- self-heal missing Break activity in getBreakActivity
-- update greeting in real-time at period boundaries
-- persist breakPrecedingContext across crashes
-- skip system activities in weekly chart injection
-- prevent crash when clicking floating alert buttons
-- attribute cross-midnight sessions to correct day
-- play lotus bloom animation once per app session
-- replace static now-indicator with pulsing active block
-- unify activity colors and sort legends across timeline and chart
-- select activity on appear when navigation pending
-- add descriptive prompt to CLI install auth dialog
-- consolidate CLI help text into install section
-- move CLI version status inline with Install button
-- stabilize chart colors and prevent future session creation
-- track active intervals for accurate hourly breakdown
-- install xcodegen and harden workflow permissions
-- include active session in Today stats
-- improve activity breakdown with time ranges, paused time, state icons, and consistent empty state
-- pass timer settings on quick restart; add Recent label and restart icon
-- align single-session rows with hidden chevron placeholder
-- add Today heading to stats GroupBox matching ChartCard style
-- apply security hardening and expand design/* labels
-- replace @State with computed property to prevent cancel animation replay
-- stabilize list width with GeometryReader layout
-- sort activities alphabetically instead of by updatedAt
-- show full date in weekly chart tooltips
-- centralize empty state layout into shared modifier
-- top-align empty state in activities detail pane
-- resolve concurrency warnings in MarkdownEditor list continuation
-- suppress unused return value warning in untagActivity
-- resolve Swift 6 concurrency warnings in StatusItemMenuManager
-- allow vertical resizing of settings window
-- replace deprecated plotAreaFrame with plotFrame
-- allow resizing settings window
-- constrain MarkdownEditor to 700pt max width
-- apply hover background to PaletteRow
-- merge two overlapping sound toggles into one
-- explicitly dismiss popover when Settings is clicked
-- clear stale data before reloading to prevent chart crash
-- honor week start preference in monthly summaries and improve drill-down
-- align weekly chart bars with x-axis labels for custom week start days
-- prevent crash when switching periods by resetting chart state
-- increase font sizes across detail view for better readability
-- clear strikethrough when unchecking markdown checkboxes
-- reduce inline edit activation to single-click
-- reorder archive alert buttons to follow macOS conventions
-- remove non-functional flash animation from timer completion
-- align period selector to content width
-- align picker, round y-axis, fix week-start crash
-- show archived activities by default
-- refine chart axis labels and tooltip behavior
-- improve chart title prominence and spacing
-- improve controls layout and date formatting
-- replace raw .accentColor with theme.accent in PaletteRow
-- replace force unwraps with safe optional handling
-- hide decorative icons from VoiceOver
-- add VoiceOver labels to activity toolbar buttons
-- add accessibility labels to session control buttons
-- apply theme palette to system controls and selections
-- prevent infinite render loop in palette preview
-- rename executable to present-cli and fix install button
-- center session type picker and cap rhythm presets to 4 options
-- make right-click menu actions work reliably
-- top-align content across all views and improve layout consistency
-- expand activity list and detail panes to full height
-- eliminate timer flickering and simplify running session UI
-- top-align activities list and detail views
-- prevent refreshAll from overriding paused state
-- replace broken sheet with direct session start
-- replace URL scheme with openWindow and add quit button
 
 ### Other
 - Merge pull request #313 from terriann/fix/bump-version-awk
@@ -538,31 +335,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Merge pull request #169 from terriann/feat/benchmark-infra
 - Merge pull request #166 from terriann/feat/0.2.0
 - Merge pull request #141 from terriann/feat/0.2/refactor
-- Merge pull request #139 from terriann/feat/0.1.0
-- Merge branch 'main' into feat/0.1.0
-- Merge branch 'main' of github.com:terriann/present
-- Merge pull request #93 from terriann/feat/0.1.0
-- Merge pull request #91 from terriann/feat/0.1.0
-- Merge pull request #90 from terriann/feat/0.1.0
-- Merge pull request #84 from terriann/fix/beta-script-stale-main
-- Merge pull request #80 from terriann/feat/0.1.0
-- Merge pull request #74 from terriann/feat/0.1.0
-- Merge pull request #48 from terriann/fix/session-hourly-breakdown
-- Merge remote-tracking branch 'origin/feat/app-initialization' into fix/session-hourly-breakdown
-- Merge pull request #46 from terriann/feat/release-pipeline
-- Merge pull request #45 from terriann/feat/dashboard-header-redesign
-- Merge pull request #44 from terriann/copilot/auto-label-new-issues
-- Merge branch 'feat/app-initialization' into copilot/auto-label-new-issues
-- restore workflow to pre-edit state
-- Merge pull request #41 from terriann/add-claude-github-actions-1771562424936
-- Initial plan
-- "Claude Code Review workflow"
-- "Claude PR Assistant workflow"
-- Add Phase 5: CI workflow, build scripts, and documentation
-- Add Phase 4: cancel command, IPC tests, and CLI workflow tests
-- Add Phase 3: Markdown editor, notifications, activity detail, and log filtering
-- Add Phase 2 app shell: SwiftUI views, menu bar, and XcodeGen config
-- Add Phase 1 foundation: PresentCore library, CLI, and tests
+
 ## [1.0.0] - 2026-02-20
 
 Initial release of Present — a simple, intentional time tracking app for macOS.
@@ -660,5 +433,6 @@ Requires:
 * feat(ipc): Unix domain socket IPC so CLI mutations are reflected in the running app in real time
 * feat(app): user-facing error feedback for failed operations
 
-[Unreleased]: https://github.com/terriann/present/compare/1.0.0...HEAD
-[1.0.0]: https://github.com/terriann/present/releases/tag/1.0.0
+[Unreleased]: https://github.com/terriann/present/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/terriann/present/compare/v0.1.0-beta.5...v0.2.1
+[1.0.0]: https://github.com/terriann/present/releases/tag/v0.1.0-beta.1

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -44,10 +44,16 @@ fi
 
 PREV_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | grep -v '-' | grep -v "^${TAG}$" | sort -V | tail -1 || true)
 
+# If no previous stable tag, fall back to any tag (including betas) so
+# the changelog is scoped to this milestone rather than all commits.
+if [[ -z "$PREV_TAG" ]]; then
+    PREV_TAG=$(git tag -l 'v[0-9]*' | grep -v "^${TAG}$" | sort -V | tail -1 || true)
+fi
+
 if [[ -n "$PREV_TAG" ]]; then
     echo "    Changes: $PREV_TAG..HEAD"
 else
-    echo "    Changes: (all commits — no previous stable tag found)"
+    echo "    Changes: (all commits — no previous tag found)"
 fi
 
 # ── Regenerate CHANGELOG.md ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The v0.2.1 changelog section contained the entire commit history (~550 lines) because `release.sh` found no previous stable tag and fell back to `git log` from the beginning of time. The script now falls back to the latest tag of any kind (including betas like `v0.1.0-beta.5`) when no prior stable tag exists, so the changelog is scoped to the current milestone.

The CHANGELOG.md comparison links were also broken — `[Unreleased]` pointed to a nonexistent `1.0.0` tag and `[0.2.1]` had no link at all. Both are corrected.

## Test plan

- [ ] Run `bash -n Scripts/release.sh` to verify syntax
- [ ] Verify the comparison links at the bottom of CHANGELOG.md resolve correctly on GitHub